### PR TITLE
Update error text when pipelines are paused due to usage limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,10 +72,11 @@ runs:
 
           const handleLimitExceeded = async (body) => {
             const limit = body?.detail?.limits?.[0]?.limit
-            const limitText = limit ? ` of **${limit}** infrastructure units` : ''
+            const used = body?.detail?.limits?.[0]?.used
+            const excess = used - limit
             const devPortalUrl = 'https://app.gruntwork.io'
             const salesEmail = 'sales@gruntwork.io'
-            const message = `You've exceeded your plan's usage limit${limitText} for over **7 days**. Effective immediately, your pipelines have been paused for all of your repositories.\n\nTo continue using Pipelines, [contact sales](mailto:${salesEmail}) to upgrade your plan or request a one-time restoration of service during which you may reduce your usage. You can view your current usage in the [Gruntwork Developer Portal](${devPortalUrl}).`
+            const message = `You're now using **${used} of ${limit}** infrastructure units included in your plan—exceeding the limit by **${excess} units**. Effective immediately, **your pipelines have been paused** for all of your repositories.\n\nTo continue using Pipelines, [contact sales](mailto:${salesEmail}) to upgrade your plan or request a one-time restoration of service during which you may reduce your usage. You can view your current usage in the [Gruntwork Developer Portal](${devPortalUrl}).`
 
             await core.summary
               .addHeading('Your Pipelines have been paused')

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,9 @@ runs:
           const handleLimitExceeded = async (body) => {
             const limit = body?.detail?.limits?.[0]?.limit
             const limitText = limit ? ` of **${limit}** infrastructure units` : ''
-            const message = `You've exceeded your plan's usage limit${limitText}. To continue using Pipelines, contact sales to upgrade your plan or request a one-time restoration of service during which you may reduce your usage.`
+            const devPortalUrl = 'https://app.gruntwork.io'
+            const salesEmail = 'sales@gruntwork.io'
+            const message = `You've exceeded your plan's usage limit${limitText} for over **7 days**. Effective immediately, your pipelines have been paused for all of your repositories.\n\nTo continue using Pipelines, [contact sales](mailto:${salesEmail}) to upgrade your plan or request a one-time restoration of service during which you may reduce your usage. You can view your current usage in the [Gruntwork Developer Portal](${devPortalUrl}).`
 
             await core.summary
               .addHeading('Your Pipelines have been paused')

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -164,7 +164,7 @@ describe('pipelines-credentials action', () => {
 
       expect(core.summary.addHeading).toHaveBeenCalledWith('Your Pipelines have been paused');
       expect(core.summary.addRaw).toHaveBeenCalledWith(
-        expect.stringContaining('**100** infrastructure units')
+        expect.stringContaining('**120 of 100** infrastructure units included in your plan—exceeding the limit by **20 units**')
       );
       expect(core.summary.write).toHaveBeenCalled();
       expect(core.setOutput).toHaveBeenCalledWith('PIPELINES_TOKEN', 'fallback-pat');


### PR DESCRIPTION
## Summary

- Aligns the PR comment text shown when pipelines are paused (due to exceeding usage limits) with the enforcement email sent from the Developer Portal
- Adds "for over 7 days" and "paused for all of your repositories" language
- Makes "contact sales" a `mailto:sales@gruntwork.io` link
- Adds a link to view current usage in the Gruntwork Developer Portal